### PR TITLE
Add RHEL build support to SPNEGO module

### DIFF
--- a/mod_auth_gssapi.conf
+++ b/mod_auth_gssapi.conf
@@ -8,12 +8,20 @@
 LoadModule auth_gssapi_module modules/mod_auth_gssapi.so
 
 #
+# This module requires KeepAlive to be switched On to allow GSSAPI
+# to perform multiple round-trips during authentication.
+#
+# To use this module, client browsers must have SPNEGO switched on. 
+# See browser documentation for details.
+#
+
+#
 # Configure the module for content.
 #
 
 <IfModule mod_auth_gssapi.c>
 
-#   <Location /moonshot>
+#   <Location /secure>
 #
 #      AuthType Negotiate
 #      require valid-user

--- a/mod_auth_gssapi.conf
+++ b/mod_auth_gssapi.conf
@@ -1,0 +1,23 @@
+# RPM installations on platforms with a conf.d directory will
+# result in this file being copied into that directory for you
+# and preserved across upgrades.
+
+# For non-RPM installs, you should copy the relevant contents of
+# this file to a configuration location you control.
+
+LoadModule auth_gssapi_module modules/mod_auth_gssapi.so
+
+#
+# Configure the module for content.
+#
+
+<IfModule mod_auth_gssapi.c>
+
+#   <Location /moonshot>
+#
+#      AuthType Negotiate
+#      require valid-user
+#
+#   </Location>
+
+</IfModule>

--- a/mod_auth_gssapi.spec
+++ b/mod_auth_gssapi.spec
@@ -1,0 +1,49 @@
+Summary: GSSAPI authentication module for the Apache HTTP Server
+Name: mod_auth_gssapi
+Version: 1e738db168
+Release: 1
+License: BSD
+Group: System Environment/Daemons
+URL: http://wiki.moonshot.ja.net/
+Source0: https://github.com/janetuk/mod_auth_kerb/archive/moonshot.zip
+Source1: mod_auth_gssapi.conf
+BuildRequires: httpd-devel, krb5-devel, libtool
+
+%description
+The mod_auth_gssapi package provides support for authenticating
+users of the Apache HTTP server using the SPNEGO-based HTTP 
+Authentication protocol defined in RFC4559.
+
+%prep
+%setup -q -n mod_auth_kerb-moonshot
+
+%build
+libtoolize --copy --force && aclocal && autoreconf && automake --add-missing && autoconf
+%configure --sysconfdir=/etc --prefix=/usr --libdir=/usr/%{_lib}
+make
+
+%install
+rm -rf $RPM_BUILD_ROOT
+
+# install the DSO
+mkdir -p $RPM_BUILD_ROOT%{_libdir}/httpd/modules
+install -m 755 .libs/mod_auth_gssapi.so $RPM_BUILD_ROOT%{_libdir}/httpd/modules
+
+# install the conf.d fragment
+mkdir -p $RPM_BUILD_ROOT%{_sysconfdir}/httpd/conf.d
+install -m 644 $RPM_SOURCE_DIR/mod_auth_gssapi.conf \
+   $RPM_BUILD_ROOT%{_sysconfdir}/httpd/conf.d/auth_gssapi.conf
+
+rm -f $RPM_BUILD_ROOT%{_libdir}/httpd/modules/{*.la,*.so.*}
+
+%clean
+rm -rf $RPM_BUILD_ROOT
+
+%files
+%defattr(-,root,root,-)
+%{_sysconfdir}/httpd/conf.d/auth_gssapi.conf
+%{_libdir}/httpd/modules/*.so
+
+%changelog
+* Fri Jan 16 2015 Stefan Paetow <stefan.paetow@jisc.ac.uk> 1e738db168-1
+- Initial build.


### PR DESCRIPTION
Add RHEL build support for the SPNEGO module for Moonshot. This builds an RPM that matches RedHat specs (based on RedHat's mod_authz_ldap).
